### PR TITLE
Add extra charges only if not free shipping

### DIFF
--- a/woocommerce-extra-charges-option-to-payment-gateways-std.php
+++ b/woocommerce-extra-charges-option-to-payment-gateways-std.php
@@ -108,7 +108,7 @@ public function calculate_totals( $totals ) {
         $extra_charges_type = $extra_charges_id.'_type';
         $extra_charges = (float)get_option( $extra_charges_id);
         $extra_charges_type_value = get_option( $extra_charges_type); 
-        if($extra_charges){
+        if($extra_charges && $woocommerce->cart->shipping_total){
             if($extra_charges_type_value=="percentage"){
                 $totals -> cart_contents_total = $totals -> cart_contents_total + round(($totals -> cart_contents_total*$extra_charges)/100,2);
             }else{


### PR DESCRIPTION
Hey, thanks for the plugin first of all. 
I've got the need to use the extra charge only when the customer is paying for the shipping, so i added this code. 
Im not sure if it can be useful for someone else, but probably it needs some kind of option to toggle it on and off.